### PR TITLE
0.4.0 - Rework api to use ref counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## 0.4.0
+
+- API overhaul to use ref-counting internally to:
+  - Enable out-of-order destruction without causing leaks, crashes or double-frees
+  - Remove lifetimes, which made this api a pain to work with and almost required hacks like the `rental` crate
+- Remove `FromRaw` as it is not possible to create most structs anymore without a reference to the underlying `Device`
+- Remove `Device` initializers other then `new_from_fd`. Lifetimes do not exist anymore and it is part of the contract to drop the `Device` before closing the file descriptor.
+- Add `Device` initializer `new` that wraps any open drm device.
+- Implement the [`drm-rs`](https://github.com/Smithay/drm-rs) `Device` traits for `Device` where applicable.
+
 ## 0.3.0
 
 - Upgrade to bitflags 1.0 with associated consts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,18 @@ description = "libgbm bindings for rust"
 license = "MIT"
 documentation = "https://docs.rs/gbm"
 repository = "https://github.com/Smithay/gbm.rs"
-version = "0.3.0"
+version = "0.4.0"
 keywords = ["wayland", "gbm", "drm", "bindings"]
 categories = ["external-ffi-bindings"]
-authors = ["Drakulix (Victor Brekenfeld)"]
+authors = ["Victor Brekenfeld <github@drakulix.de>"]
 exclude = [".travis.yml", ".rustfmt.toml"]
 
 [dependencies]
 gbm-sys = { version = "0.1", path = "./gbm-sys" }
 libc = "0.2"
 bitflags = "1.0.0"
-wayland-server = { version = "~0.11.3", optional = true }
-egli = { version = "~0.2.1", optional = true }
-drm = { version = "0.3.0", optional = true }
+wayland-server = { version = "0.12", optional = true }
+drm = { version = "0.3", optional = true }
 
 [dev-dependencies]
 drm = "0.3.0"
@@ -24,6 +23,6 @@ drm = "0.3.0"
 [features]
 default = ["import-wayland", "import-egl", "drm-support"]
 import-wayland = ["wayland-server"]
-import-egl = ["egli", "egli/egl_1_5"]
+import-egl = []
 drm-support = ["drm"]
 gen = ["gbm-sys/gen"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ use gbm::{Device, Format, BufferObjectFlags};
 let drm = init_drm_device();
 
 // init a gbm device
-let gbm = Device::new_from_drm(&drm).unwrap();
+let gbm = Device::new(drm).unwrap();
 
 // create a buffer
 let mut bo = gbm.create_buffer_object::<()>(
@@ -54,8 +54,8 @@ let buffer = {
 bo.write(&buffer).unwrap();
 
 // create a framebuffer from our buffer
-let fb_info = framebuffer::create(&drm, &bo).unwrap();
+let fb_info = framebuffer::create(&gbm, &bo).unwrap();
 
 // display it (and get a crtc, mode and connector before)
-crtc::set(&drm, crtc_handle, fb_info.handle(), &[con], (0, 0), Some(mode)).unwrap();
+crtc::set(&gbm, crtc_handle, fb_info.handle(), &[con], (0, 0), Some(mode)).unwrap();
 ```

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,14 +1,14 @@
-use {AsRaw, BufferObject, BufferObjectFlags, Format, FromRaw, Surface};
+use {AsRaw, BufferObject, BufferObjectFlags, Format, Surface};
 
-#[cfg(feature = "import-egl")]
-use egli::egl::EGLImage;
+use libc::c_void;
+
+use std::error;
 use std::ffi::CStr;
-use std::marker::PhantomData;
+use std::fmt;
+use std::rc::Rc;
 use std::io::{Error as IoError, Result as IoResult};
-use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
-
-#[cfg(feature = "drm-support")]
-use drm::Device as DrmDevice;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "import-wayland")]
 use wayland_server::Resource;
@@ -16,42 +16,56 @@ use wayland_server::Resource;
 #[cfg(feature = "import-wayland")]
 use wayland_server::protocol::wl_buffer::WlBuffer;
 
-/// An open DRM device
-pub struct Device<'a> {
-    ffi: *mut ::ffi::gbm_device,
-    _lifetime: PhantomData<&'a ()>,
-}
+#[cfg(feature = "import-egl")]
+/// An EGLImage handle
+pub type EGLImage = *mut c_void;
 
-impl<'a> AsRawFd for Device<'a> {
+#[cfg(feature = "drm-support")]
+use drm::Device as DrmDevice;
+#[cfg(feature = "drm-support")]
+use drm::control::Device as DrmControlDevice;
+
+/// Type wrapping a foreign file destructor
+pub struct FdWrapper(RawFd);
+
+impl AsRawFd for FdWrapper {
     fn as_raw_fd(&self) -> RawFd {
-        unsafe { ::ffi::gbm_device_get_fd(self.ffi) }
+        self.0
     }
 }
 
-impl<'a> AsRaw<::ffi::gbm_device> for Device<'a> {
+/// An open GBM device
+pub struct Device<T: AsRawFd + 'static> {
+    fd: T,
+    ffi: Rc<*mut ::ffi::gbm_device>,
+}
+
+impl<T: AsRawFd + 'static> AsRawFd for Device<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        unsafe { ::ffi::gbm_device_get_fd(*self.ffi) }
+    }
+}
+
+impl<T: AsRawFd + 'static> AsRaw<::ffi::gbm_device> for Device<T> {
     fn as_raw(&self) -> *const ::ffi::gbm_device {
-        self.ffi
+        *self.ffi
     }
 }
 
-impl<'a> FromRaw<::ffi::gbm_device> for Device<'a> {
-    unsafe fn from_raw(ffi: *mut ::ffi::gbm_device) -> Self {
-        Device { ffi: ffi, _lifetime: PhantomData }
+impl<T: AsRawFd + 'static> Deref for Device<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.fd
     }
 }
 
-impl<'a> Device<'a> {
-    /// Open a GBM device from a given IO object taking ownership
-    pub fn new<I: IntoRawFd>(io: I) -> IoResult<Device<'static>> {
-        unsafe { Device::new_from_fd(io.into_raw_fd()) }
+impl<T: AsRawFd + 'static> DerefMut for Device<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.fd
     }
+}
 
-    /// Open a GBM device from a given DRM device
-    #[cfg(feature = "drm-support")]
-    pub fn new_from_drm<D: DrmDevice + AsRawFd + 'a>(drm: &'a D) -> IoResult<Device<'a>> {
-        unsafe { Device::new_from_fd(drm.as_raw_fd()) }
-    }
-
+impl Device<FdWrapper> {
     /// Open a GBM device from a given unix file descriptor.
     ///
     /// The file descriptor passed in is used by the backend to communicate with
@@ -61,22 +75,43 @@ impl<'a> Device<'a> {
     /// # Unsafety
     ///
     /// The lifetime of the resulting device depends on the ownership of the file descriptor.
-    /// If the fd will be controlled by the device a static lifetime is valid, if it does not own the fd
-    /// the lifetime may not outlive the owning object.
+    /// Closing the file descriptor before dropping the Device will lead to undefined behavior.
     ///
-    pub unsafe fn new_from_fd(fd: RawFd) -> IoResult<Device<'a>> {
+    pub unsafe fn new_from_fd(fd: RawFd) -> IoResult<Device<FdWrapper>> {
         let ptr = ::ffi::gbm_create_device(fd);
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(Device { ffi: ptr, _lifetime: PhantomData })
+            Ok(Device {
+                fd: FdWrapper(fd),
+                ffi: Rc::new(ptr),
+            })
+        }
+    }
+}
+
+impl<T: AsRawFd + 'static> Device<T> {
+    /// Open a GBM device from a given open DRM device.
+    ///
+    /// The underlying file descriptor passed in is used by the backend to communicate with
+    /// platform for allocating the memory. For allocations using DRI this would be
+    /// the file descriptor returned when opening a device such as /dev/dri/card0.
+    pub fn new(fd: T) -> IoResult<Device<T>> {
+        let ptr = unsafe { ::ffi::gbm_create_device(fd.as_raw_fd()) };
+        if ptr.is_null() {
+            Err(IoError::last_os_error())
+        } else {
+            Ok(Device {
+                fd: fd,
+                ffi: Rc::new(ptr),
+            })
         }
     }
 
     /// Get the backend name
     pub fn backend_name(&self) -> &str {
         unsafe {
-            CStr::from_ptr(::ffi::gbm_device_get_backend_name(self.ffi))
+            CStr::from_ptr(::ffi::gbm_device_get_backend_name(*self.ffi))
                 .to_str()
                 .expect("GBM passed invalid utf8 string")
         }
@@ -86,7 +121,7 @@ impl<'a> Device<'a> {
     pub fn is_format_supported(&self, format: Format, usage: BufferObjectFlags) -> bool {
         unsafe {
             ::ffi::gbm_device_is_format_supported(
-                self.ffi,
+                *self.ffi,
                 format.as_ffi(),
                 usage.bits(),
             ) != 0
@@ -94,16 +129,16 @@ impl<'a> Device<'a> {
     }
 
     /// Allocate a new surface object
-    pub fn create_surface<T: 'static>(
-        &'a self,
+    pub fn create_surface<U: 'static>(
+        &self,
         width: u32,
         height: u32,
         format: Format,
         usage: BufferObjectFlags,
-    ) -> IoResult<Surface<'a, T>> {
+    ) -> IoResult<Surface<U>> {
         let ptr = unsafe {
             ::ffi::gbm_surface_create(
-                self.ffi,
+                *self.ffi,
                 width,
                 height,
                 format.as_ffi(),
@@ -113,21 +148,21 @@ impl<'a> Device<'a> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { Surface::from_raw(ptr) })
+            Ok(unsafe { Surface::new(ptr, Rc::downgrade(&self.ffi)) })
         }
     }
 
     ///  Allocate a buffer object for the given dimensions
-    pub fn create_buffer_object<T: 'static>(
-        &'a self,
+    pub fn create_buffer_object<U: 'static>(
+        &self,
         width: u32,
         height: u32,
         format: Format,
         usage: BufferObjectFlags,
-    ) -> IoResult<BufferObject<'a, T>> {
+    ) -> IoResult<BufferObject<U>> {
         let ptr = unsafe {
             ::ffi::gbm_bo_create(
-                self.ffi,
+                *self.ffi,
                 width,
                 height,
                 format.as_ffi(),
@@ -137,11 +172,11 @@ impl<'a> Device<'a> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::from_raw(ptr) })
+            Ok(unsafe { BufferObject::new(ptr, Rc::downgrade(&self.ffi)) })
         }
     }
 
-    ///  Create a gbm buffer object from a wayland buffer
+    /// Create a gbm buffer object from a wayland buffer
     ///
     /// This function imports a foreign `WlBuffer` object and creates a new gbm
     /// buffer object for it.
@@ -150,14 +185,14 @@ impl<'a> Device<'a> {
     /// The gbm bo shares the underlying pixels but its life-time is
     /// independent of the foreign object.
     #[cfg(feature = "import-wayland")]
-    pub fn import_buffer_object_from_wayland<T: 'static>(
-        &'a self,
+    pub fn import_buffer_object_from_wayland<U: 'static>(
+        &self,
         buffer: &WlBuffer,
         usage: BufferObjectFlags,
-    ) -> IoResult<BufferObject<'a, T>> {
+    ) -> IoResult<BufferObject<U>> {
         let ptr = unsafe {
             ::ffi::gbm_bo_import(
-                self.ffi,
+                *self.ffi,
                 ::ffi::GBM_BO_IMPORT::WL_BUFFER as u32,
                 buffer.ptr() as *mut _,
                 usage.bits(),
@@ -166,11 +201,11 @@ impl<'a> Device<'a> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::from_raw(ptr) })
+            Ok(unsafe { BufferObject::new(ptr, Rc::downgrade(&self.ffi)) })
         }
     }
 
-    ///  Create a gbm buffer object from an egl buffer
+    /// Create a gbm buffer object from an egl buffer
     ///
     /// This function imports a foreign `EGLImage` object and creates a new gbm
     /// buffer object for it.
@@ -178,28 +213,32 @@ impl<'a> Device<'a> {
     ///
     /// The gbm bo shares the underlying pixels but its life-time is
     /// independent of the foreign object.
+    ///
+    /// ## Unsafety
+    ///
+    /// The given EGLImage is a raw pointer. Passing null or an invalid EGLImage will
+    /// cause undefined behavior.
     #[cfg(feature = "import-egl")]
-    pub fn import_buffer_object_from_egl<T: 'static>(
-        &'a self,
-        buffer: &EGLImage,
+    pub unsafe fn import_buffer_object_from_egl<U: 'static>(
+        &self,
+        buffer: EGLImage,
         usage: BufferObjectFlags,
-    ) -> IoResult<BufferObject<'a, T>> {
-        let ptr = unsafe {
+    ) -> IoResult<BufferObject<U>> {
+        let ptr =
             ::ffi::gbm_bo_import(
-                self.ffi,
+                *self.ffi,
                 ::ffi::GBM_BO_IMPORT::EGL_IMAGE as u32,
-                *buffer,
+                buffer,
                 usage.bits(),
-            )
-        };
+            );
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::from_raw(ptr) })
+            Ok(BufferObject::new(ptr, Rc::downgrade(&self.ffi)))
         }
     }
 
-    ///  Create a gbm buffer object from an dma buffer
+    /// Create a gbm buffer object from an dma buffer
     ///
     /// This function imports a foreign dma buffer from an open file descriptor
     /// and creates a new gbm buffer object for it.
@@ -207,15 +246,15 @@ impl<'a> Device<'a> {
     ///
     /// The gbm bo shares the underlying pixels but its life-time is
     /// independent of the foreign object.
-    pub fn import_buffer_object_from_dma_buf<T: 'static>(
-        &'a self,
+    pub fn import_buffer_object_from_dma_buf<U: 'static>(
+        &self,
         buffer: RawFd,
         width: u32,
         height: u32,
         stride: u32,
         format: Format,
         usage: BufferObjectFlags,
-    ) -> IoResult<BufferObject<'a, T>> {
+    ) -> IoResult<BufferObject<U>> {
         let mut fd_data = ::ffi::gbm_import_fd_data {
             fd: buffer,
             width: width,
@@ -226,7 +265,7 @@ impl<'a> Device<'a> {
 
         let ptr = unsafe {
             ::ffi::gbm_bo_import(
-                self.ffi,
+                *self.ffi,
                 ::ffi::GBM_BO_IMPORT::FD as u32,
                 &mut fd_data as *mut ::ffi::gbm_import_fd_data as *mut _,
                 usage.bits(),
@@ -235,13 +274,38 @@ impl<'a> Device<'a> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::from_raw(ptr) })
+            Ok(unsafe { BufferObject::new(ptr, Rc::downgrade(&self.ffi)) })
         }
     }
 }
 
-impl<'a> Drop for Device<'a> {
+#[cfg(feature = "drm-support")]
+impl<T: DrmDevice + AsRawFd + 'static> DrmDevice for Device<T> {}
+
+#[cfg(feature = "drm-support")]
+impl<T: DrmControlDevice + AsRawFd + 'static> DrmControlDevice for Device<T> {}
+
+impl<T: AsRawFd + 'static> Drop for Device<T> {
     fn drop(&mut self) {
-        unsafe { ::ffi::gbm_device_destroy(self.ffi) };
+        unsafe { ::ffi::gbm_device_destroy(*self.ffi) };
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Thrown when the underlying gbm device was already destroyed
+pub struct DeviceDestroyedError;
+
+impl fmt::Display for DeviceDestroyedError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        write!(f, "{}", self.description())
+    }
+}
+
+impl error::Error for DeviceDestroyedError {
+    fn description(&self) -> &str {
+        "The underlying gbm device was already destroyed"
+    }
+
+    fn cause(&self) -> Option<&error::Error> { None }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! let drm = init_drm_device();
 //!
 //! // init a gbm device
-//! let gbm = Device::new_from_drm(&drm).unwrap();
+//! let gbm = Device::new(drm).unwrap();
 //!
 //! // create a 4x4 buffer
 //! let mut bo = gbm.create_buffer_object::<()>(
@@ -70,16 +70,16 @@
 //! bo.write(&buffer).unwrap();
 //!
 //! // create a framebuffer from our buffer
-//! let fb_info = framebuffer::create(&drm, &bo).unwrap();
+//! let fb_info = framebuffer::create(&gbm, &bo).unwrap();
 //!
-//! # let res_handles = drm.resource_handles().unwrap();
+//! # let res_handles = gbm.resource_handles().unwrap();
 //! # let con = *res_handles.connectors().iter().next().unwrap();
 //! # let crtc_handle = *res_handles.crtcs().iter().next().unwrap();
-//! # let connector_info: ConnectorInfo = drm.resource_info(con).unwrap();
+//! # let connector_info: ConnectorInfo = gbm.resource_info(con).unwrap();
 //! # let mode: Mode = connector_info.modes()[0];
 //! #
 //! // display it (and get a crtc, mode and connector before)
-//! crtc::set(&drm, crtc_handle, fb_info.handle(), &[con], (0, 0), Some(mode)).unwrap();
+//! crtc::set(&gbm, crtc_handle, fb_info.handle(), &[con], (0, 0), Some(mode)).unwrap();
 //! # }
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,6 @@ extern crate libc;
 #[cfg(feature = "import-wayland")]
 extern crate wayland_server;
 
-#[cfg(feature = "import-egl")]
-extern crate egli;
-
 #[cfg(feature = "drm-support")]
 extern crate drm;
 
@@ -117,28 +114,6 @@ pub trait AsRaw<T> {
     fn as_raw_mut(&self) -> *mut T {
         self.as_raw() as *mut _
     }
-}
-
-/// Trait for types that allow to be initialized from a raw pointer
-pub trait FromRaw<T> {
-    /// Create a new instance of this type from a raw pointer.
-    ///
-    /// ## Warning
-    ///
-    /// If you make use of [`Userdata`](./trait.Userdata.html) make sure you use the correct types
-    /// to allow receiving the set userdata. When dealing with raw pointers initialized by other
-    /// libraries this must be done extra carefully to select a correct representation.
-    ///
-    /// If unsure using `()` is always a safe option.
-    ///
-    /// ## Unsafety
-    ///
-    /// If the pointer is pointing to a different struct, invalid memory or `NULL` the returned
-    /// struct may panic on use or cause other undefined behavior.
-    ///
-    /// Effectively cloning objects by using `as_raw` and `from_raw` is also unsafe as
-    /// a double free may occur.
-    unsafe fn from_raw(*mut T) -> Self;
 }
 
 /// Possible pixel formats used


### PR DESCRIPTION
From CHANGELOG.md:

## 0.4.0

- API overhaul to use ref-counting internally to:
  - Enable out-of-order destruction without causing leaks, crashes or double-frees
  - Remove lifetimes, which made this api a pain to work with and almost required hacks like the `rental` crate
- Remove `FromRaw` as it is not possible to create most structs anymore without a reference to the underlying `Device`
- Remove `Device` initializers other then `new_from_fd`. Lifetimes do not exist anymore and it is part of the contract to drop the `Device` before closing the file descriptor.
- Add `Device` initializer `new` that wraps any open drm device.
- Implement the [`drm-rs`](https://github.com/Smithay/drm-rs) `Device` traits for `Device` where applicable.



This will most likely be the future 0.4.0 version. This PR will remain open until the changes are tested in [`smithay`](https://github.com/Smithay/smithay) and have proven themselves.