### PR TITLE
Autoformat documentation examples and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ provided through the `drm-support` feature.
 
 Add to your Cargo.toml
 
-`gbm = "0.2.2"`
+```toml
+gbm = "0.2.2"
+```
 
 ## Example
 
@@ -23,8 +25,8 @@ Add to your Cargo.toml
 extern crate drm;
 extern crate gbm;
 
-use drm::control::{crtc, framebuffer};
-use gbm::{Device, Format, BufferObjectFlags};
+use drm::control::{self, crtc, framebuffer};
+use gbm::{BufferObjectFlags, Device, Format};
 
 // ... init your drm device ...
 let drm = init_drm_device();
@@ -33,13 +35,14 @@ let drm = init_drm_device();
 let gbm = Device::new(drm).unwrap();
 
 // create a buffer
-let mut bo = gbm.create_buffer_object::<()>(
-            1280, 720,
-            Format::ARGB8888,
-            &[
-                BufferObjectFlags::Scanout,
-                BufferObjectFlags::Write,
-            ]).unwrap();
+let mut bo = gbm
+    .create_buffer_object::<()>(
+        1280,
+        720,
+        Format::Argb8888,
+        BufferObjectFlags::SCANOUT | BufferObjectFlags::WRITE,
+    )
+    .unwrap();
 
 // write something to it (usually use import or egl rendering instead)
 let buffer = {
@@ -54,8 +57,9 @@ let buffer = {
 bo.write(&buffer).unwrap();
 
 // create a framebuffer from our buffer
-let fb_info = framebuffer::create(&gbm, &bo).unwrap();
+let fb = gbm.add_framebuffer(&bo, 32, 32).unwrap();
 
 // display it (and get a crtc, mode and connector before)
-crtc::set(&gbm, crtc_handle, fb_info.handle(), &[con], (0, 0), Some(mode)).unwrap();
+gbm.set_crtc(crtc_handle, Some(fb), (0, 0), &[con], Some(mode))
+    .unwrap();
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,27 +14,28 @@
 //! ## Example
 //!
 //! ```rust,no_run
-//! extern crate drm;
-//! extern crate gbm;
-//!
-//! use drm::control::{self, crtc, framebuffer};
-//! # use drm::control::Mode;
+//! # extern crate drm;
+//! # extern crate gbm;
 //! # use drm::control::connector::Info as ConnectorInfo;
-//! use gbm::{Device, Format, BufferObjectFlags};
+//! # use drm::control::Mode;
+//! use drm::control::{self, crtc, framebuffer};
+//! use gbm::{BufferObjectFlags, Device, Format};
 //!
-//! # use std::fs::{OpenOptions, File};
+//! # use std::fs::{File, OpenOptions};
 //! # use std::os::unix::io::{AsRawFd, RawFd};
 //! #
-//! # use drm::Device as BasicDevice;
 //! # use drm::control::Device as ControlDevice;
+//! # use drm::Device as BasicDevice;
 //! # struct Card(File);
 //! #
 //! # impl AsRawFd for Card {
-//! #     fn as_raw_fd(&self) -> RawFd { self.0.as_raw_fd() }
+//! #     fn as_raw_fd(&self) -> RawFd {
+//! #         self.0.as_raw_fd()
+//! #     }
 //! # }
 //! #
-//! # impl BasicDevice for Card { }
-//! # impl ControlDevice for Card { }
+//! # impl BasicDevice for Card {}
+//! # impl ControlDevice for Card {}
 //! #
 //! # fn init_drm_device() -> Card {
 //! #     let mut options = OpenOptions::new();
@@ -51,12 +52,14 @@
 //! let gbm = Device::new(drm).unwrap();
 //!
 //! // create a 4x4 buffer
-//! let mut bo = gbm.create_buffer_object::<()>(
-//!             1280, 720,
-//!             Format::Argb8888,
-//!             BufferObjectFlags::SCANOUT | BufferObjectFlags::WRITE,
-//!             ).unwrap();
-//!
+//! let mut bo = gbm
+//!     .create_buffer_object::<()>(
+//!         1280,
+//!         720,
+//!         Format::Argb8888,
+//!         BufferObjectFlags::SCANOUT | BufferObjectFlags::WRITE,
+//!     )
+//!     .unwrap();
 //! // write something to it (usually use import or egl rendering instead)
 //! let buffer = {
 //!     let mut buffer = Vec::new();
@@ -79,7 +82,8 @@
 //! # let mode: Mode = connector_info.modes()[0];
 //! #
 //! // display it (and get a crtc, mode and connector before)
-//! gbm.set_crtc(crtc_handle, Some(fb), (0, 0), &[con], Some(mode)).unwrap();
+//! gbm.set_crtc(crtc_handle, Some(fb), (0, 0), &[con], Some(mode))
+//!     .unwrap();
 //! # }
 //! ```
 


### PR DESCRIPTION
As mentioned in [1] the documentation example could use some autoformatting, and recent API changes have to be propagated into the README too.

[1]: https://github.com/Smithay/gbm.rs/pull/4#issuecomment-819313998

---

I'm curious if we should just paste the full working example in `README`, that's much clearer IMO, or refernce. @katyo given your CI efforts you might like https://docs.rs/doc-comment/, a crate that (build)tests the documentation in arbitrary markdown files like `README.md` from `build.rs`. If we put a fully working example here we can also make sure that it stays in a compiling state :)