### PR TITLE
Use `OwnedFd`/`BorrowedFd` instead of `RawFd`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - run: sudo apt-get install -y libdrm-dev libwayland-dev
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.63.0
           profile: minimal
           components: clippy
           default: true
@@ -79,12 +79,12 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-rust_1_60-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-rust_1_63-${{ hashFiles('**/Cargo.toml') }}
       - name: Build cache
         uses: actions/cache@v2
         with:
           path: target
-          key: ${{ runner.os }}-build-rust_1_60-check-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-build-rust_1_63-check-${{ hashFiles('**/Cargo.toml') }}
       - name: Clippy check
         uses: actions-rs/clippy-check@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["wayland", "gbm", "drm", "bindings"]
 categories = ["external-ffi-bindings"]
 authors = ["Victoria Brekenfeld <github@drakulix.de>"]
 exclude = [".gitignore", ".travis.yml", ".rustfmt.toml", ".github"]
+edition = "2021"
 
 [dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ version = "0.2.1"
 path = "./gbm-sys"
 
 [dependencies.drm]
-version = "0.7.0"
+ version = "0.8.0"
 optional = true
 
 [dependencies.wayland-server]
@@ -34,7 +34,7 @@ features = ["server_system"]
 optional = true
 
 [dev-dependencies.drm]
-version = "0.7.0"
+ version = "0.8.0"
 
 [features]
 default = ["import-wayland", "import-egl", "drm-support"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,15 +22,15 @@
 //! use gbm::{BufferObjectFlags, Device, Format};
 //!
 //! # use std::fs::{File, OpenOptions};
-//! # use std::os::unix::io::{AsRawFd, RawFd};
+//! # use std::os::unix::io::{AsFd, BorrowedFd, RawFd};
 //! #
 //! # use drm::control::Device as ControlDevice;
 //! # use drm::Device as BasicDevice;
 //! # struct Card(File);
 //! #
-//! # impl AsRawFd for Card {
-//! #     fn as_raw_fd(&self) -> RawFd {
-//! #         self.0.as_raw_fd()
+//! # impl AsFd for Card {
+//! #     fn as_fd(&self) -> BorrowedFd {
+//! #         self.0.as_fd()
 //! #     }
 //! # }
 //! #
@@ -186,18 +186,20 @@ unsafe impl<T> Send for WeakPtr<T> where Ptr<T>: Send {}
 
 #[cfg(test)]
 mod test {
+    use std::os::unix::io::OwnedFd;
+
     fn is_send<T: Send>() {}
 
     #[test]
     fn device_is_send() {
         is_send::<super::Device<std::fs::File>>();
-        is_send::<super::Device<super::FdWrapper>>();
+        is_send::<super::Device<OwnedFd>>();
     }
 
     #[test]
     fn surface_is_send() {
         is_send::<super::Surface<std::fs::File>>();
-        is_send::<super::Surface<super::FdWrapper>>();
+        is_send::<super::Surface<OwnedFd>>();
     }
 
     #[test]


### PR DESCRIPTION
`Device::new_from_fd()` should now be safe since it takes ownership of an `OwnedFd`, but I guess it may be desirable for it to work without ownership of the fd? But then `Device` shouldn't require `T: 'static`.
    
A couple things here would be neater if drm-rs is also updated to use these types.
