### PR TITLE
auto detection for fd_for_plane

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["wayland", "gbm", "drm", "bindings"]
 categories = ["external-ffi-bindings"]
 authors = ["Victoria Brekenfeld <github@drakulix.de>"]
 exclude = [".gitignore", ".travis.yml", ".rustfmt.toml", ".github"]
+build = "build.rs"
 
 [dependencies]
 libc = "0.2"
@@ -30,12 +31,17 @@ optional = true
 [dev-dependencies.drm]
 version = "0.7.0"
 
+[build-dependencies.cc]
+version = "1.0"
+optional = true
+
 [features]
-default = ["import-wayland", "import-egl", "drm-support"]
+default = ["import-wayland", "import-egl", "drm-support", "auto-detect"]
 import-wayland = ["wayland-server"]
 import-egl = []
 drm-support = ["drm"]
 gen = ["gbm-sys/gen"]
+auto-detect = ["cc"]
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+#[cfg(feature = "auto-detect")]
+fn main() {
+    let has_gbm_bo_get_fd_for_plane = cc::Build::new()
+        .file("test_gbm_bo_get_fd_for_plane.c")
+        .warnings_into_errors(true)
+        .try_compile("test_gbm_bo_get_fd_for_plane")
+        .is_ok();
+
+    if has_gbm_bo_get_fd_for_plane {
+        println!("cargo:rustc-cfg=HAS_GBM_BO_GET_FD_FOR_PLANE");
+    }
+}
+
+#[cfg(not(feature = "auto-detect"))]
+fn main() {}

--- a/test_gbm_bo_get_fd_for_plane.c
+++ b/test_gbm_bo_get_fd_for_plane.c
@@ -1,0 +1,5 @@
+#include <gbm.h>
+
+void test() {
+    gbm_bo_get_fd_for_plane(NULL, 0);
+}


### PR DESCRIPTION
An attempt to auto-detect availability of `gbm_bo_get_handle_for_plane`.
Default feature tries to auto detect, when disabled it always assumes availability of `gbm_bo_get_handle_for_plane`