### PR TITLE
Use strong references to `gbm_device` in `Surface`/`BufferObject`

### DIFF
--- a/src/buffer_object.rs
+++ b/src/buffer_object.rs
@@ -235,12 +235,12 @@ impl<T: 'static> BufferObject<T> {
     /// handle for the buffer object.  Each call to [`Self::fd()`] returns a new
     /// file descriptor and the caller is responsible for closing the file
     /// descriptor.
-    pub fn fd(&self) -> Result<OwnedFd, FdError> {
+    pub fn fd(&self) -> Result<OwnedFd, InvalidFdError> {
         unsafe {
             let fd = ffi::gbm_bo_get_fd(*self.ffi);
 
             if fd == -1 {
-                return Err(InvalidFdError.into());
+                return Err(InvalidFdError);
             }
 
             Ok(OwnedFd::from_raw_fd(fd))
@@ -266,12 +266,12 @@ impl<T: 'static> BufferObject<T> {
     /// handle for a plane of the buffer object. Each call to [`Self::fd_for_plane()`]
     /// returns a new file descriptor and the caller is responsible for closing
     /// the file descriptor.
-    pub fn fd_for_plane(&self, plane: i32) -> Result<OwnedFd, FdError> {
+    pub fn fd_for_plane(&self, plane: i32) -> Result<OwnedFd, InvalidFdError> {
         unsafe {
             let fd = ffi::gbm_bo_get_fd_for_plane(*self.ffi, plane);
 
             if fd == -1 {
-                return Err(InvalidFdError.into());
+                return Err(InvalidFdError);
             }
 
             Ok(OwnedFd::from_raw_fd(fd))
@@ -596,32 +596,3 @@ impl fmt::Display for InvalidFdError {
 }
 
 impl error::Error for InvalidFdError {}
-
-/// Thrown when an error occurs during getting a bo fd
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FdError {
-    /// The operation returned an invalid fd
-    InvalidFd(InvalidFdError),
-}
-
-impl From<InvalidFdError> for FdError {
-    fn from(err: InvalidFdError) -> Self {
-        FdError::InvalidFd(err)
-    }
-}
-
-impl fmt::Display for FdError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            FdError::InvalidFd(err) => err.fmt(f),
-        }
-    }
-}
-
-impl error::Error for FdError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self {
-            FdError::InvalidFd(err) => Some(err),
-        }
-    }
-}

--- a/src/device.rs
+++ b/src/device.rs
@@ -2,7 +2,6 @@ use crate::{AsRaw, BufferObject, BufferObjectFlags, Format, Modifier, Ptr, Surfa
 
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd};
 
-use std::error;
 use std::ffi::CStr;
 use std::fmt;
 use std::io::{Error as IoError, Result as IoResult};
@@ -134,7 +133,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { Surface::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { Surface::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -160,7 +159,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { Surface::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { Surface::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -188,7 +187,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { Surface::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { Surface::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -205,7 +204,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { BufferObject::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -231,7 +230,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { BufferObject::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -259,7 +258,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { BufferObject::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -290,7 +289,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { BufferObject::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -322,7 +321,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(BufferObject::new(ptr, self.ffi.downgrade()))
+            Ok(BufferObject::new(ptr, self.ffi.clone()))
         }
     }
 
@@ -362,7 +361,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { BufferObject::new(ptr, self.ffi.clone()) })
         }
     }
 
@@ -410,7 +409,7 @@ impl<T: AsFd> Device<T> {
         if ptr.is_null() {
             Err(IoError::last_os_error())
         } else {
-            Ok(unsafe { BufferObject::new(ptr, self.ffi.downgrade()) })
+            Ok(unsafe { BufferObject::new(ptr, self.ffi.clone()) })
         }
     }
 }
@@ -420,19 +419,3 @@ impl<T: DrmDevice + AsFd> DrmDevice for Device<T> {}
 
 #[cfg(feature = "drm-support")]
 impl<T: DrmControlDevice + AsFd> DrmControlDevice for Device<T> {}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-/// Thrown when the underlying GBM device was already destroyed
-pub struct DeviceDestroyedError;
-
-impl fmt::Display for DeviceDestroyedError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "The underlying GBM device was already destroyed")
-    }
-}
-
-impl error::Error for DeviceDestroyedError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -22,16 +22,11 @@ impl<T: 'static> fmt::Debug for Surface<T> {
 
 /// Errors that may happen when locking the front buffer
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FrontBufferError {
-    /// An unknown error happened
-    Unknown,
-}
+pub struct FrontBufferError;
 
 impl fmt::Display for FrontBufferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            FrontBufferError::Unknown => write!(f, "Unknown error"),
-        }
+        write!(f, "Unknown error")
     }
 }
 
@@ -74,7 +69,7 @@ impl<T: 'static> Surface<T> {
             };
             Ok(buffer)
         } else {
-            Err(FrontBufferError::Unknown)
+            Err(FrontBufferError)
         }
     }
 

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,12 +1,13 @@
-use crate::{AsRaw, BufferObject, DeviceDestroyedError, Ptr, WeakPtr};
+use crate::{AsRaw, BufferObject, Ptr};
 use std::error;
 use std::fmt;
 use std::marker::PhantomData;
 
 /// A GBM rendering surface
 pub struct Surface<T: 'static> {
+    // Declare `ffi` first so it is dropped before `_device`
     ffi: Ptr<ffi::gbm_surface>,
-    _device: WeakPtr<ffi::gbm_device>,
+    _device: Ptr<ffi::gbm_device>,
     _bo_userdata: PhantomData<T>,
 }
 
@@ -24,27 +25,17 @@ impl<T: 'static> fmt::Debug for Surface<T> {
 pub enum FrontBufferError {
     /// An unknown error happened
     Unknown,
-    /// Device was already released
-    Destroyed(DeviceDestroyedError),
 }
 
 impl fmt::Display for FrontBufferError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             FrontBufferError::Unknown => write!(f, "Unknown error"),
-            FrontBufferError::Destroyed(ref err) => write!(f, "Buffer was destroyed: {}", err),
         }
     }
 }
 
-impl error::Error for FrontBufferError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            FrontBufferError::Destroyed(ref err) => Some(err),
-            _ => None,
-        }
-    }
-}
+impl error::Error for FrontBufferError {}
 
 impl<T: 'static> Surface<T> {
     ///  Return whether or not a surface has free (non-locked) buffers
@@ -55,12 +46,7 @@ impl<T: 'static> Surface<T> {
     /// [have been locked](Self::lock_front_buffer()),
     /// the application must check for a free buffer before rendering.
     pub fn has_free_buffers(&self) -> bool {
-        let device = self._device.upgrade();
-        if device.is_some() {
-            unsafe { ffi::gbm_surface_has_free_buffers(*self.ffi) != 0 }
-        } else {
-            false
-        }
+        unsafe { ffi::gbm_surface_has_free_buffers(*self.ffi) != 0 }
     }
 
     /// Lock the surface's current front buffer
@@ -76,32 +62,25 @@ impl<T: 'static> Surface<T> {
     /// on the surface or two or more times after `eglSwapBuffers` is an
     /// error and may cause undefined behavior.
     pub unsafe fn lock_front_buffer(&self) -> Result<BufferObject<T>, FrontBufferError> {
-        let device = self._device.upgrade();
-        if device.is_some() {
-            let buffer_ptr = ffi::gbm_surface_lock_front_buffer(*self.ffi);
-            if !buffer_ptr.is_null() {
-                let surface_ptr = self.ffi.downgrade();
-                let buffer = BufferObject {
-                    ffi: Ptr::new(buffer_ptr, move |ptr| {
-                        if let Some(surface) = surface_ptr.upgrade() {
-                            ffi::gbm_surface_release_buffer(*surface, ptr);
-                        }
-                    }),
-                    _device: self._device.clone(),
-                    _userdata: std::marker::PhantomData,
-                };
-                Ok(buffer)
-            } else {
-                Err(FrontBufferError::Unknown)
-            }
+        let buffer_ptr = ffi::gbm_surface_lock_front_buffer(*self.ffi);
+        if !buffer_ptr.is_null() {
+            let surface_ptr = self.ffi.clone();
+            let buffer = BufferObject {
+                ffi: Ptr::new(buffer_ptr, move |ptr| {
+                    ffi::gbm_surface_release_buffer(*surface_ptr, ptr);
+                }),
+                _device: self._device.clone(),
+                _userdata: std::marker::PhantomData,
+            };
+            Ok(buffer)
         } else {
-            Err(FrontBufferError::Destroyed(DeviceDestroyedError))
+            Err(FrontBufferError::Unknown)
         }
     }
 
     pub(crate) unsafe fn new(
         ffi: *mut ffi::gbm_surface,
-        device: WeakPtr<ffi::gbm_device>,
+        device: Ptr<ffi::gbm_device>,
     ) -> Surface<T> {
         Surface {
             ffi: Ptr::new(ffi, |ptr| ffi::gbm_surface_destroy(ptr)),


### PR DESCRIPTION
Using a strong reference is the most obvious way to address https://github.com/Smithay/smithay/issues/1102. And getting rid of `DeviceDestroyedError` makes the API a fair bit cleaner.

Though `Device.fd` will also need to be reference counted for this to fix the issue here. Presumably. And this will need testing. Leaving as a draft at the moment.

Any reason not to do this, or why it may cause problems? I guess `Device` will require `T: Sync`...