### PR TITLE
Update wayland-server to 0.31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - run: sudo apt-get install -y libdrm-dev libwayland-dev
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0
+          toolchain: 1.65.0
           profile: minimal
           components: clippy
           default: true
@@ -79,12 +79,12 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-rust_1_63-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-rust_1_65-${{ hashFiles('**/Cargo.toml') }}
       - name: Build cache
         uses: actions/cache@v2
         with:
           path: target
-          key: ${{ runner.os }}-build-rust_1_63-check-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-build-rust_1_65-check-${{ hashFiles('**/Cargo.toml') }}
       - name: Clippy check
         uses: actions-rs/clippy-check@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ version = "0.9.0"
 optional = true
 
 [dependencies.wayland-server]
-version = "0.30"
+version = "0.31"
 optional = true
 
 [dependencies.wayland-backend]
-version = "0.1"
+version = "0.3"
 features = ["server_system"]
 optional = true
 


### PR DESCRIPTION
This is going to be a breaking change as wayland-server is part of the public API.

This also bumps the MSRV to 1.65