### PR TITLE
Accept `BorrowedFd` in public API methods instead of `RawFd`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! use gbm::{BufferObjectFlags, Device, Format};
 //!
 //! # use std::fs::{File, OpenOptions};
-//! # use std::os::unix::io::{AsFd, BorrowedFd, RawFd};
+//! # use std::os::unix::io::{AsFd, BorrowedFd};
 //! #
 //! # use drm::control::Device as ControlDevice;
 //! # use drm::Device as BasicDevice;


### PR DESCRIPTION
This should help ensure these function calls aren't used in unsound ways.

This is a breaking API change.