### PR TITLE
gbm-sys: Use edition 2021

### DIFF
--- a/gbm-sys/Cargo.toml
+++ b/gbm-sys/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/Drakulix/gbm.rs/tree/master/gbm-sys"
 keywords = ["gbm", "bindings"]
 categories = ["external-ffi-bindings"]
 license = "MIT"
+edition = "2021"
 
 [lib]
 path = "src/lib.rs"

--- a/gbm-sys/src/lib.rs
+++ b/gbm-sys/src/lib.rs
@@ -4,8 +4,6 @@
 // it is not so.
 #![cfg_attr(test, allow(deref_nullptr))]
 
-extern crate libc;
-
 #[cfg(feature = "gen")]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 


### PR DESCRIPTION
Doesn't make that much difference, but `gbm` already uses 2021.