### PR TITLE
Update BufferObjectFlags in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let mut bo = gbm
         1280,
         720,
         Format::Argb8888,
-        BufferObjectFlags::SCANOUT | BufferObjectFlags::WRITE,
+        BufferObjectFlags::SCANOUT | BufferObjectFlags::CURSOR | BufferObjectFlags::WRITE,
     )
     .unwrap();
 


### PR DESCRIPTION
Without including `BufferObjectFlags::CURSOR`, I was getting the following error:

`Os { code: 22, kind: InvalidInput, message: "Invalid argument" }`
