### PR TITLE
Update bitflags dependency to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ version = "0.3"
 features = ["server_system"]
 optional = true
 
+[dependencies.serde]
+version = "1"
+features = ["derive"]
+optional = true
+
 [dev-dependencies.drm]
 version = "0.11.0"
 
@@ -42,6 +47,7 @@ import-wayland = ["wayland-server", "wayland-backend"]
 import-egl = []
 drm-support = ["drm"]
 use_bindgen = ["gbm-sys/use_bindgen"]
+serde = ["dep:serde", "bitflags/serde"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.2"
+bitflags = "2"
 drm-fourcc = "2.2"
 
 [dependencies.gbm-sys]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,10 @@ features = ["server_system"]
 optional = true
 
 [dependencies.serde]
-version = "1"
+# Minimal serde version that can compile serde-annotated bitflags v2.
+# Workaround that allows -Z minimal-versions build to succeed despite bitflags
+# crate not declaring minimum versions of its dependencies precisely enough.
+version = "1.0.103"
 features = ["derive"]
 optional = true
 

--- a/src/buffer_object.rs
+++ b/src/buffer_object.rs
@@ -40,6 +40,7 @@ bitflags! {
     ///
     /// Use [`Device::is_format_supported()`] to check if the combination of format
     /// and use flags are supported
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize), serde(transparent))]
     #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
     pub struct BufferObjectFlags: u32 {
         /// Buffer is going to be presented to the screen using an API such as KMS

--- a/src/buffer_object.rs
+++ b/src/buffer_object.rs
@@ -40,6 +40,7 @@ bitflags! {
     ///
     /// Use [`Device::is_format_supported()`] to check if the combination of format
     /// and use flags are supported
+    #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
     pub struct BufferObjectFlags: u32 {
         /// Buffer is going to be presented to the screen using an API such as KMS
         const SCANOUT      = ffi::gbm_bo_flags::GBM_BO_USE_SCANOUT as u32;
@@ -58,6 +59,19 @@ bitflags! {
         const LINEAR       = ffi::gbm_bo_flags::GBM_BO_USE_LINEAR as u32;
         /// Buffer is protected
         const PROTECTED    = ffi::gbm_bo_flags::GBM_BO_USE_PROTECTED as u32;
+    }
+}
+
+impl BufferObjectFlags {
+    /// Create BufferObjectFlags from u32, preserving all bits (even undefined ones).
+    ///
+    /// This was provided by bitflags! macro in v1 and was replaced in v2 by safe from_bits_retain.
+    ///
+    /// # Safety
+    /// This function is safe. The unsafe marker was left for exact source compatibility.
+    #[deprecated = "Use from_bits_retain instead"]
+    pub const unsafe fn from_bits_unchecked(bits: u32) -> Self {
+        Self::from_bits_retain(bits)
     }
 }
 

--- a/src/buffer_object.rs
+++ b/src/buffer_object.rs
@@ -62,19 +62,6 @@ bitflags! {
     }
 }
 
-impl BufferObjectFlags {
-    /// Create BufferObjectFlags from u32, preserving all bits (even undefined ones).
-    ///
-    /// This was provided by bitflags! macro in v1 and was replaced in v2 by safe from_bits_retain.
-    ///
-    /// # Safety
-    /// This function is safe. The unsafe marker was left for exact source compatibility.
-    #[deprecated = "Use from_bits_retain instead"]
-    pub const unsafe fn from_bits_unchecked(bits: u32) -> Self {
-        Self::from_bits_retain(bits)
-    }
-}
-
 /// Abstraction representing the handle to a buffer allocated by the manager
 pub type BufferObjectHandle = ffi::gbm_bo_handle;
 


### PR DESCRIPTION
Currently, `cargo tree` run shows the crate depending on both bitflags v1 (directly) and v2 (through dependencies). However, the crate seems to compile just fine with bitflags v2.