### PR TITLE
Bump `gbm-sys` version to 0.3.1

### DIFF
--- a/gbm-sys/Cargo.toml
+++ b/gbm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gbm-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Drakulix (Victor Brekenfeld)"]
 build = "build.rs"
 description = "Bindgen generated unsafe libgbm wrapper"


### PR DESCRIPTION
e9e3764 changed a couple lines in `gbm-sys`, so it needs a version bump as well.